### PR TITLE
Upgrade to latest version of vault, add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,31 @@
+---
+driver:
+  # we cannot use the docker driver since we depend on systemd
+  name: vagrant
+  use_sudo: false
+
+provisioner:
+  name: ansible_playbook
+  require_ansible_repo: true
+  require_chef_omnibus: false
+  hosts: host
+
+platforms:
+  - name: ubuntu-16.04
+  - name: centos-7.2
+  - name: debian-8
+
+verifier:
+  name: serverspec
+  sudo_path: true
+
+suites:
+  - name: default
+    run_list:
+    attributes:
+    verifier:
+      default_pattern: true
+      # see https://github.com/neillturner/kitchen-verifier-serverspec/issues/29
+      additional_serverspec_command: 'if [ ! -f /tmp/verifier/suites ]; then mkdir -p /tmp/verifier/suites && ln -sf /tmp/verifier/serverspec /tmp/verifier/suites/serverspec; fi'
+      bundler_path: /usr/local/bin
+      rspec_path: /usr/local/bin

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "test-kitchen", "~> 1.17.0"
+gem "kitchen-vagrant"
+gem "kitchen-ansible"
+gem "kitchen-verifier-serverspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,78 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    artifactory (2.8.2)
+    diff-lcs (1.3)
+    kitchen-ansible (0.47.5)
+      net-ssh (>= 3)
+      test-kitchen (~> 1.4)
+    kitchen-vagrant (1.2.1)
+      test-kitchen (~> 1.4)
+    kitchen-verifier-serverspec (0.6.9)
+      net-ssh (>= 3)
+      test-kitchen (~> 1.4)
+    mixlib-install (2.1.12)
+      artifactory
+      mixlib-shellout
+      mixlib-versioning
+      thor
+    mixlib-shellout (2.3.2)
+    mixlib-versioning (1.2.2)
+    multi_json (1.12.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (4.2.0)
+    net-ssh-gateway (1.3.0)
+      net-ssh (>= 2.6.5)
+    net-telnet (0.1.1)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+    safe_yaml (1.0.4)
+    serverspec (2.40.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.68)
+    sfl (2.3)
+    specinfra (2.71.2)
+      net-scp
+      net-ssh (>= 2.7, < 5.0)
+      net-telnet
+      sfl
+    test-kitchen (1.17.0)
+      mixlib-install (>= 1.2, < 3.0)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-gateway (~> 1.2)
+      safe_yaml (~> 1.0)
+      thor (~> 0.19, < 0.19.2)
+    thor (0.19.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kitchen-ansible
+  kitchen-vagrant
+  kitchen-verifier-serverspec
+  net-ssh (~> 4)
+  serverspec
+  test-kitchen (~> 1.17.0)
+
+BUNDLED WITH
+   1.15.4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
-vault_version: 0.7.1
-vault_checksum: a576fe2c717ea4b5968477757196ff5308dbded4f5083c91d9e2ea824d2d6fdc
+vault_version: 0.8.2
+vault_checksum: b7050bbc0b9ad554dd03040d1e5ad9c3b0cafde7e781f65433e4db5d05882245
 vault_platform: linux_amd64
+vault_config: vault.hcl.j2

--- a/files/vault.systemd
+++ b/files/vault.systemd
@@ -8,9 +8,8 @@ ConditionFileNotEmpty=/etc/vault.hcl
 Restart=on-failure
 User=vault
 Group=vault
-PermissionsStartOnly=true
-ExecStartPre=/sbin/setcap 'cap_ipc_lock=+ep' /usr/local/bin/vault
 ExecStart=/usr/local/bin/vault server -config=/etc/vault.hcl
+ExecReload=/usr/bin/kill --signal HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install a Hashicorp Vault server
   company: Wizcorp KK
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.2
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,6 @@
   group:
     name: vault
     system: yes
-  tags: ['vault']
 
 - name: "Create the vault user"
   user:
@@ -10,14 +9,12 @@
     groups: "{{ vault_groups|default('vault') }}"
     createhome: no
     system: yes
-  tags: ['vault']
 
 - name: "Check installed vault version"
   shell: vault version | grep -Po '(?<=Vault v)(\d+.\d+.\d+)'
   ignore_errors: True
   changed_when: False
   register: vault_installed_version
-  tags: ['vault']
 
 - name: "Download vault"
   get_url:
@@ -29,7 +26,6 @@
     mode: 0644
   register: vault_download
   when: vault_installed_version|failed or vault_installed_version.stdout != vault_version
-  tags: ['vault']
 
 - name: "Make sure that unzip is installed"
   package: name=unzip state=present
@@ -44,19 +40,25 @@
     mode: 0755
   when: vault_installed_version|failed or vault_installed_version.stdout != vault_version
   notify: Restart vault
-  tags: ['vault']
+
+# See https://www.vaultproject.io/docs/configuration/index.html#disable_mlock
+# about why this is necessary
+- name: "Set vault binary capabilities"
+  capabilities:
+    path: /usr/local/bin/vault
+    capability: cap_ipc_lock=+ep
+    state: present
 
 - name: "Create vault directories"
   file:
     path: "{{ item }}"
     owner: vault
     group: vault
-    mode: 0755
+    mode: 0750
     state: directory
   with_items:
     - /var/log/vault
     - /var/lib/vault
-  tags: ['vault']
 
 - name: "Configure vault"
   template:
@@ -64,9 +66,8 @@
     src: "{{ vault_config }}"
     owner: vault
     group: vault
-    mode: 0644
+    mode: 0640
   notify: Restart vault
-  tags: ['vault', 'files']
 
 - name: "Install the systemd unit file"
   copy:
@@ -75,12 +76,10 @@
     owner: root
     group: root
     mode: 0644
-  notify: Reload systemd
-  tags: ['vault', 'files']
 
 - name: "Ensure vault is started and enabled on boot"
-  service:
+  systemd:
+    daemon_reload: yes
     name: vault
     state: started
     enabled: yes
-  tags: ['vault']

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -2,7 +2,7 @@
  * Vault configuration. See: https://vaultproject.io/docs/config/
  */
 
-backend "file" {
+storage "file" {
 	path = "/var/lib/vault"
 }
 

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -1,0 +1,3 @@
+- hosts: all
+  roles:
+    - ansible-vault

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,26 @@
+require_relative 'spec_helper'
+
+describe service('vault') do
+	it { should be_enabled }
+	it { should be_running }
+end
+
+describe file('/etc/vault.hcl') do
+	it { should exist }
+	it { should be_file }
+	it { should be_owned_by 'vault' }
+	it { should be_grouped_into 'vault' }
+	it { should be_mode 640 }
+end
+
+describe file('/var/lib/vault') do
+	it { should exist }
+	it { should be_directory }
+	it { should be_owned_by 'vault' }
+	it { should be_grouped_into 'vault' }
+	it { should be_mode 750 }
+end
+
+describe port(8200) do
+	it { should be_listening }
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'serverspec'
+set :backend, :exec


### PR DESCRIPTION
* Vault `0.8.2`
* Minimum version of `ansible` is now `2.2`
* Added missing `vault_config` variable to defaults
* Added reload to service file
* Remove setcap from service file, do it on install
* Removed tags
* Removed `/var/lib/vault` and config access to all
* Updated config to use `storage` instead of `backend`
* Added `test-kitchen` (uses `vagrant` driver)

Might want to do a bump to `1.1.0` for release since the config format changed