### PR TITLE
Update to 0.8.3, also fix small cap issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-vault_version: 0.8.2
-vault_checksum: b7050bbc0b9ad554dd03040d1e5ad9c3b0cafde7e781f65433e4db5d05882245
+vault_version: 0.8.3
+vault_checksum: a3b687904cd1151e7c7b1a3d016c93177b33f4f9ce5254e1d4f060fca2ac2626
 vault_platform: linux_amd64
 vault_config: vault.hcl.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
 - name: "Set vault binary capabilities"
   capabilities:
     path: /usr/local/bin/vault
-    capability: cap_ipc_lock=+ep
+    capability: cap_ipc_lock+ep
     state: present
 
 - name: "Create vault directories"


### PR DESCRIPTION
Capabilities were being set properly, but the `=` in there was causing the playbook to re-apply the caps every time it was running.